### PR TITLE
Add support for sync and promise in runnables.

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -3,7 +3,7 @@
  */
 
 var Suite = require('../suite');
-var Test = require('../test');
+var Test = require('../overrides/test');
 var escapeRe = require('escape-string-regexp');
 
 /**

--- a/lib/interfaces/exports.js
+++ b/lib/interfaces/exports.js
@@ -3,7 +3,7 @@
  */
 
 var Suite = require('../suite');
-var Test = require('../test');
+var Test = require('../overrides/test');
 
 /**
  * TDD-style interface:

--- a/lib/interfaces/qunit.js
+++ b/lib/interfaces/qunit.js
@@ -3,7 +3,7 @@
  */
 
 var Suite = require('../suite');
-var Test = require('../test');
+var Test = require('../overrides/test');
 var escapeRe = require('escape-string-regexp');
 
 /**

--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -3,7 +3,7 @@
  */
 
 var Suite = require('../suite');
-var Test = require('../test');
+var Test = require('../overrides/test');
 var escapeRe = require('escape-string-regexp');
 
 /**

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -39,8 +39,8 @@ exports.Runnable = require('./overrides/runnable');
 exports.Context = require('./context');
 exports.Runner = require('./overrides/runner');
 exports.Suite = require('./suite');
-exports.Hook = require('./hook');
-exports.Test = require('./test');
+exports.Hook = require('./overrides/hook');
+exports.Test = require('./overrides/test');
 
 /**
  * Return image `name` path.

--- a/lib/overrides/hook.js
+++ b/lib/overrides/hook.js
@@ -1,0 +1,63 @@
+/**
+ * Module dependencies.
+ */
+
+var Runnable = require('./runnable');
+var create = require('lodash.create');
+
+/**
+ * Expose `Hook`.
+ */
+
+module.exports = Hook;
+
+/**
+ * Initialize a new `Hook` with the given `title` and callback `fn`.
+ *
+ * @param {String} title
+ * @param {Function} fn
+ * @api private
+ */
+function Hook(title, fn) {
+  Runnable.call(this, title, fn);
+  this.type = 'hook';
+  if (this.title !== '"before each" hook') {
+    var self = this;
+    this.fn = fn && function() {
+      var result = fn.apply(this, [self._nightwatch.api()].concat(Array.prototype.slice.call(arguments)));
+
+      if (self._nightwatch.shouldRestartQueue()) {
+        self._nightwatch.start();
+      }
+
+      return result;
+    };
+    this.async = fn && fn.length > 1;
+    this.sync = !this.async;
+  }
+}
+
+/**
+ * Inherit from `Runnable.prototype`.
+ */
+
+Hook.prototype = create(Runnable.prototype, {
+  constructor: Hook
+});
+
+/**
+ * Get or set the test `err`.
+ *
+ * @param {Error} err
+ * @return {Error}
+ * @api public
+ */
+Hook.prototype.error = function(err) {
+  if (!arguments.length) {
+    err = this._error;
+    this._error = null;
+    return err;
+  }
+
+  this._error = err;
+};

--- a/lib/overrides/runnable.js
+++ b/lib/overrides/runnable.js
@@ -1,19 +1,17 @@
 var create = require('lodash.create');
 var MochaRunnable = require('../runnable');
-var utils = require('../utils');
 
 module.exports = Runnable;
 
 function Runnable(title, fn) {
-  this.title = title;
-  this.fn = fn;
-  this.async = 1;
-  this.sync = false;
+  MochaRunnable.call(this, title);
+  var self = this;
+  this.fn = fn && function() {
+    return fn.apply(this, [self._nightwatch.api()].concat(Array.prototype.slice.call(arguments)));
+  };
+  this.async = fn && fn.length > 1;
+  this.sync = !this.async;
   this._timeout = 20000;
-  this._slow = 75;
-  this._enableTimeouts = true;
-  this.timedOut = false;
-  this._trace = new Error('done() called multiple times');
 }
 
 Runnable.prototype = create(MochaRunnable.prototype, {
@@ -24,100 +22,4 @@ Runnable.prototype.setNightwatchClient = function(client) {
   this._nightwatch = client;
   this._nightwatch.clearGlobalResult();
   return this;
-};
-
-/**
- * Run the test and invoke `fn(err)`.
- *
- * @api private
- * @param {Function} fn
- */
-Runnable.prototype.run = function(fn) {
-  var self = this;
-  var start = new Date();
-  var ctx = this.ctx;
-  var finished;
-  var emitted;
-
-  // Sometimes the ctx exists, but it is not runnable
-  if (ctx && ctx.runnable) {
-    ctx.runnable(this);
-  }
-
-  // called multiple times
-  function multiple(err) {
-    if (emitted) {
-      return;
-    }
-    emitted = true;
-    self.emit('error', err || new Error('done() called multiple times; stacktrace may be inaccurate'));
-  }
-
-  // finished
-  function done(err) {
-    if (self.timedOut) {
-      return;
-    }
-
-    if (finished) {
-      return multiple(err || self._trace);
-    }
-
-    self.clearTimeout();
-    self.duration = new Date() - start;
-    finished = true;
-    fn(err);
-  }
-
-  // for .resetTimeout()
-  this.callback = done;
-
-  try {
-    if (this.type == 'test') {
-      var module = [];
-      if (this.parent.parent.title) {
-        module.push(this.parent.parent.title);
-      }
-      module.push(this.parent.title);
-      var moduleTitle = module.join('/').toLocaleLowerCase().replace(/\s+/g,'-');
-
-      this._nightwatch.api('currentTest', {
-        name : this.title,
-        module : moduleTitle
-      });
-    }
-
-    var args = [this._nightwatch.api()];
-
-    if (this.type == 'hook') {
-      args.push(done);
-      // explicit async with `done` argument
-      this.resetTimeout();
-    }
-
-    // TODO: support sync hooks
-    this.fn.apply(ctx, args);
-    if (this.type == 'hook' && this.title == '"before each" hook') {
-      // don't restart the queue for before each
-      return;
-    }
-    if (this.type == 'test') {
-      this._nightwatch.once('complete', function() {
-        self.duration = new Date() - start;
-        finished = true;
-        var results = this.results();
-        var err = null;
-        if (results.failed > 0 || results.errors > 0) {
-          err = results.lastError;
-        }
-        fn(err);
-      });
-    }
-
-    if (this._nightwatch.shouldRestartQueue()) {
-      this._nightwatch.start();
-    }
-  } catch (err) {
-    done(utils.getError(err));
-  }
 };

--- a/lib/overrides/test.js
+++ b/lib/overrides/test.js
@@ -1,0 +1,97 @@
+/**
+ * Module dependencies.
+ */
+
+var Runnable = require('./runnable');
+var create = require('lodash.create');
+var _Promise;
+if (Promise) {
+  _Promise = Promise;
+} else {
+  _Promise = require('promise');
+}
+/**
+ * Expose `Test`.
+ */
+
+module.exports = Test;
+
+function noop() {}
+
+/**
+ * Initialize a new `Test` with the given `title` and callback `fn`.
+ *
+ * @api private
+ * @param {String} title
+ * @param {Function} fn
+ */
+function Test(title, fn) {
+  Runnable.call(this, title);
+  this.pending = !fn;
+  this.type = 'test';
+  if (this.pending) {
+    this.fn = noop;
+  } else {
+    var self = this;
+    this.originalAsync = fn.length > 1;
+
+    this.fn = function() {
+      var module = [];
+      if (self.parent.parent.title) {
+        module.push(self.parent.parent.title);
+      }
+      module.push(self.parent.title);
+      var moduleTitle = module.join('/').toLocaleLowerCase().replace(/\s+/g, '-');
+
+      self._nightwatch.api('currentTest', {
+        name: self.title,
+        module: moduleTitle
+      });
+
+      var ctx = this; // It might be different in Runnable:run
+      var promises = [];
+
+      if (self.originalAsync) {
+        promises.push(new _Promise(function(resolve, reject) {
+          fn.call(ctx, self._nightwatch.api(), function(err) {
+            err ? reject(err) : resolve();
+          });
+        }));
+      } else {
+        var p = fn.call(ctx, self._nightwatch.api());
+        if (p && typeof p.then === 'function') {
+          promises.push(p);
+        }
+      }
+
+      promises.push(new _Promise(function(resolve, reject) {
+        self._nightwatch.once('complete', function() {
+          var results = this.results();
+          var err = null;
+          if (results.failed > 0 || results.errors > 0) {
+            err = results.lastError;
+          }
+          err ? reject(err) : resolve();
+        });
+
+        if (self._nightwatch.shouldRestartQueue()) {
+          self._nightwatch.start();
+        }
+      }));
+
+      // Fulfilled when both "complete" hook and async/promise fulfilled.
+      // Reject with first encountered reason.
+      return _Promise.all(promises);
+    };
+  }
+  this.async = false;
+  this.sync = true;
+}
+
+/**
+ * Inherit from `Runnable.prototype`.
+ */
+
+Test.prototype = create(Runnable.prototype, {
+  constructor: Test
+});

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -3,7 +3,7 @@
  */
 
 var EventEmitter = require('events').EventEmitter;
-var Hook = require('./hook');
+var Hook = require('./overrides/hook');
 var create = require('lodash.create');
 var debug = require('debug')('mocha:suite');
 var milliseconds = require('./ms');

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "jade": "0.26.3",
     "lodash.create": "^3.1.1",
     "mkdirp": "0.5.0",
+    "promise": "^7.1.1",
     "supports-color": "1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
#6 
In "hook" type runnable, the runnable function just provide a NightWatch api. The runnable function without a callback will no longer be restricted, but it won't wait for NightWatch unless they are combined explicitly.
In "test" type runnable, the runnable function will complete only when both function and NightWatch session finished.